### PR TITLE
Build for 3.12, drop 3.7

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -17,11 +17,11 @@ jobs:
           - 'macos-latest'
           - 'windows-latest'
         python:
-          - '3.7'
           - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
+          - '3.12'
 
     runs-on: ${{ matrix.os }}
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: build sdist
         run: python -m build --sdist
-        if: ${{ matrix.os == 'macos-latest' && matrix.python == '3.9' }}
+        if: ${{ matrix.os == 'macos-latest' && matrix.python == '3.12' }}
 
       - name: Store the packages
         uses: actions/upload-artifact@v2
@@ -64,11 +64,11 @@ jobs:
       fail-fast: false
       matrix:
         python:
-          - 'cp37-cp37m'
           - 'cp38-cp38'
           - 'cp39-cp39'
           - 'cp310-cp310'
           - 'cp311-cp311'
+          - 'cp312-cp312'
 
     runs-on: ubuntu-latest
     container: quay.io/pypa/manylinux2014_x86_64


### PR DESCRIPTION
3.12 has released and 3.7 is past end-of-life.